### PR TITLE
Add example simulation on argon from the lab series

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In the project top directory, do
     conda create -n salsa_dancing_molecules
     conda activate salsa_dancing_molecules
     conda install pip
+    pip install numpy # needed because of broken asap3 dependencies
     pip install -e .
 
 and answer yes to all questions to create an environment called
@@ -41,6 +42,7 @@ In the project top directory, do
 
     python3 -m venv virtualenv
     source virtualenv/bin/activate
+    pip install numpy # needed because of broken asap3 dependencies
     pip install -e .
 
 to create a virtual environment, activate it and install a development

--- a/salsa_dancing_molecules/simulations/__init__.py
+++ b/salsa_dancing_molecules/simulations/__init__.py
@@ -1,0 +1,10 @@
+"""Contains different MD simulations to run.
+
+Call the run() function on a specific simulation to run it:
+
+    from salsa_dancing_molecules.simulations import argon
+
+    # Runs the simulation for 10 fs, with a simulation size of 5*5*5
+    # and saves the output to ar.traj.
+    argon.run(10)
+"""

--- a/salsa_dancing_molecules/simulations/argon.py
+++ b/salsa_dancing_molecules/simulations/argon.py
@@ -1,0 +1,51 @@
+"""Demonstrates molecular dynamics with constant energy."""
+
+from ase.lattice.cubic import FaceCenteredCubic
+from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
+from ase.md.verlet import VelocityVerlet
+from ase import units
+from asap3 import Trajectory, LennardJones, EMT
+
+
+def run(steps, cell_size=5, output_path='ar.traj'):
+    """Run an MD simulation for argon in a FCC configuration.
+
+    Arguments:
+        steps - the number of steps in the simulation, one step is
+                equal to 1 fs.
+        cell_size - the number of repetitions in all dimensions of the
+                    minimal unit cell. Default is a 5*5*5 repetition.
+        output_path - path to which to save the generated trajectory
+                      data. Default is to save to "ar.traj".
+    """
+    # Set up a crystal
+    atoms = FaceCenteredCubic(directions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                              symbol="Ar",
+                              size=(cell_size, cell_size, cell_size),
+                              latticeconstant=5.256,
+                              pbc=True)
+
+    # Describe the interatomic interactions with the L-J
+    atoms.calc = LennardJones(18, 0.010323, 3.40, rCut=6.625, modified=True)
+
+    # Set the momenta corresponding to T=300K
+    MaxwellBoltzmannDistribution(atoms, temperature_K=40)
+
+    # We want to run MD with constant energy using the VelocityVerlet
+    # algorithm.
+    dyn = VelocityVerlet(atoms, 1 * units.fs)  # 5 fs time step.
+    traj = Trajectory(output_path, "w", atoms)
+    dyn.attach(traj.write, interval=100)
+
+    def printenergy(a=atoms):
+        """Print the potential, kinetic and total energy."""
+        epot = a.get_potential_energy() / len(a)
+        ekin = a.get_kinetic_energy() / len(a)
+        print('Energy per atom: Epot = %.3feV  Ekin = %.3feV (T=%3.0fK)  '
+              'Etot = %.3feV' % (epot, ekin, ekin / (1.5 * units.kB),
+                                 epot + ekin))
+
+    # Now run the dynamics
+    dyn.attach(printenergy, interval=10)
+    printenergy()
+    dyn.run(steps)

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ setup(
           "Programming Language :: Python :: 3 :: Only",
     ],
     packages=find_packages(where="."),
-    python_requires=">=3.6",
-    install_requires=[],
+    python_requires=">=3.7",
+    install_requires=['ase', 'asap3'],
     entry_points={
         "console_scripts": [
             "salsa-dancing-molecules=salsa_dancing_molecules:main",


### PR DESCRIPTION
This adds the argon simulation from the lab series as an example simulation. To facilitate this, ASE and ASAP are added as dependencies.

ASAP has broken dependencies and needs numpy to install. I tried, and failed, to figure out a good way to force our setup.py script to install numpy before trying to install ASAP, but this use case is not supported at all. Instead, I've added an instruction to the README to install numpy before installing our project.

If we want to do something about this, we should report the issue to the ASAP developers.