### PR TITLE
workflows: unit_tests: add asap3 to test environment

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest numpy ase matplotlib
+          pip install asap3
       - name: Running tests
         run: |
           pytest


### PR DESCRIPTION
Since salsa_dancing_molecules imports main that imports asap3, we need the dependency in the test environment.