### PR TITLE
Add command to run an NVE simulation with materials from Materials Project

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pytest and dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest numpy ase matplotlib
+          pip install pytest numpy ase matplotlib mp_api
           pip install asap3
       - name: Running tests
         run: |

--- a/salsa_dancing_molecules/cli/main.py
+++ b/salsa_dancing_molecules/cli/main.py
@@ -31,6 +31,12 @@ def main():
                             help=('Chemical formula of the material to fetch '
                                   'from materialsproject and simulate.  '
                                   '(Default: Ar)'), default='Ar')
+    nve_parser.add_argument('--repeat',
+                            help=('Optional number to repeat the '
+                                  'material cell in all three dimensions. '
+                                  'This is usefull if the downloaded '
+                                  'material cell is too small.'),
+                            type=int, default=0)
     nve_parser.add_argument('api_key',
                             help=('API key for materialsproject.org '
                                   'needed for fetching material structures to '
@@ -48,7 +54,7 @@ def main():
 
     if 'formula' in args:
         nve.run_for_materials(args.formula, args.api_key, args.steps,
-                              args.output_file)
+                              args.output_file, args.repeat)
     elif 'steps' in args:
         argon.run(args.steps, args.cell_size, args.output_path)
 

--- a/salsa_dancing_molecules/cli/main.py
+++ b/salsa_dancing_molecules/cli/main.py
@@ -1,7 +1,7 @@
 """Module containing the main function of the simulation software."""
 import argparse
 import sys
-from ..simulations import argon
+from ..simulations import argon, nve
 
 
 def main():
@@ -26,9 +26,30 @@ def main():
                             'trajectory data. Default is to save to "ar.traj"',
                             nargs='?', default="ar.traj")
 
+    nve_parser = command_parser.add_parser('nve', help='Run an NVE simulation')
+    nve_parser.add_argument('formula',
+                            help=('Chemical formula of the material to fetch '
+                                  'from materialsproject and simulate.  '
+                                  '(Default: Ar)'), default='Ar')
+    nve_parser.add_argument('api_key',
+                            help=('API key for materialsproject.org '
+                                  'needed for fetching material structures to '
+                                  'simulate.'))
+    nve_parser.add_argument('steps',
+                            help=('Steps: Number of steps to run '
+                                  '(1 step = 1 fs)'), type=int)
+    nve_parser.add_argument('output_file',
+                            help=('Output file for trajectory data. '
+                                  'The file will be named '
+                                  '$output_file-$formula.traj '
+                                  'for each material'))
+
     args = parser.parse_args()
 
-    if 'steps' in args:
+    if 'formula' in args:
+        nve.run_for_materials(args.formula, args.api_key, args.steps,
+                              args.output_file)
+    elif 'steps' in args:
         argon.run(args.steps, args.cell_size, args.output_path)
 
 

--- a/salsa_dancing_molecules/simulations/argon.py
+++ b/salsa_dancing_molecules/simulations/argon.py
@@ -1,10 +1,7 @@
-"""Demonstrates molecular dynamics with constant energy."""
+"""Helpers to run an example simulation on Argon."""
 
 from ase.lattice.cubic import FaceCenteredCubic
-from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
-from ase.md.verlet import VelocityVerlet
-from ase import units
-from asap3 import Trajectory, LennardJones, EMT
+from .nve import run as nve_run
 
 
 def run(steps, cell_size=5, output_path='ar.traj'):
@@ -18,34 +15,10 @@ def run(steps, cell_size=5, output_path='ar.traj'):
         output_path - path to which to save the generated trajectory
                       data. Default is to save to "ar.traj".
     """
-    # Set up a crystal
+    # Set up an example Argon crystal
     atoms = FaceCenteredCubic(directions=[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
                               symbol="Ar",
                               size=(cell_size, cell_size, cell_size),
                               latticeconstant=5.256,
                               pbc=True)
-
-    # Describe the interatomic interactions with the L-J
-    atoms.calc = LennardJones(18, 0.010323, 3.40, rCut=6.625, modified=True)
-
-    # Set the momenta corresponding to T=300K
-    MaxwellBoltzmannDistribution(atoms, temperature_K=40)
-
-    # We want to run MD with constant energy using the VelocityVerlet
-    # algorithm.
-    dyn = VelocityVerlet(atoms, 1 * units.fs)  # 5 fs time step.
-    traj = Trajectory(output_path, "w", atoms)
-    dyn.attach(traj.write, interval=100)
-
-    def printenergy(a=atoms):
-        """Print the potential, kinetic and total energy."""
-        epot = a.get_potential_energy() / len(a)
-        ekin = a.get_kinetic_energy() / len(a)
-        print('Energy per atom: Epot = %.3feV  Ekin = %.3feV (T=%3.0fK)  '
-              'Etot = %.3feV' % (epot, ekin, ekin / (1.5 * units.kB),
-                                 epot + ekin))
-
-    # Now run the dynamics
-    dyn.attach(printenergy, interval=10)
-    printenergy()
-    dyn.run(steps)
+    nve_run(atoms, steps, output_path)

--- a/salsa_dancing_molecules/simulations/nve.py
+++ b/salsa_dancing_molecules/simulations/nve.py
@@ -1,0 +1,80 @@
+"""Implements molecular dynamics with constant energy."""
+
+from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
+from ase.md.verlet import VelocityVerlet
+from ase import units
+from asap3 import Trajectory, AsapError
+from ..materialsproject import MatClient
+
+
+def run_for_materials(formula, api_key, steps, output_path):
+    """Run an MD simulation for Materials Project materials.
+
+    Arguments:
+        formula: str     - the formula of the materials to simulate. Ex: C-O
+        api_key: str     - materialsproject.org API key for downloading
+                           materials
+        steps: int       - the number of 1 fs steps to run the simulation for
+        output_path: str - path to which to save the generated trajectory
+                           data. They get saved to $output_path-$formula.traj.
+    """
+    with MatClient(api_key) as client:
+        atoms_list = client.get_atoms(formula)
+
+    for (i, atoms) in enumerate(atoms_list):
+        print(f'Simulating material {i + 1} of {len(atoms_list)}')
+
+        symbols = atoms.symbols
+        output_name = f'{output_path}-{symbols}.traj'
+
+        try:
+            print(f'Simulating for {symbols}')
+            run(atoms, steps, output_name)
+        except AsapError as e:
+            print(f'ASAP3 error for {symbols}: {e}')
+            print('Trying without ASAP3...')
+            run(atoms, steps, output_name, False)
+
+
+def run(atoms, steps, output_path, use_asap=True):
+    """Run an MD simulation for atoms.
+
+    Arguments:
+        atoms: Atoms     - ASE Atoms object for which to run the simulation.
+        steps: int       - the number of steps in the simulation, one step is
+                           equal to 1 fs.
+        output_path:str  - path to which to save the generated trajectory
+                           data. They get saved to $output_path-$formula.traj.
+        use_asap: bool   - Whether to use ASAP3 to calculate the potential.
+    """
+    # Describe the interatomic interactions with the L-J
+    # FIXME: This Lennard-Jones potential is currently hard coded for Argon.
+    if use_asap:
+        from asap3 import LennardJones
+        atoms.calc = LennardJones(18, 0.010323, 3.40, rCut=6.625,
+                                  modified=True)
+    else:
+        from ase.calculators.lj import LennardJones
+        atoms.calc = LennardJones(epsilon=0.010323, sigma=3.40, rc=6.625)
+
+    # Set the momenta corresponding to T=300K
+    MaxwellBoltzmannDistribution(atoms, temperature_K=40)
+
+    # We want to run MD with constant energy using the VelocityVerlet
+    # algorithm.
+    dyn = VelocityVerlet(atoms, 1 * units.fs)  # 5 fs time step.
+    traj = Trajectory(output_path, "w", atoms)
+    dyn.attach(traj.write, interval=100)
+
+    def printenergy(a=atoms):
+        """Print the potential, kinetic and total energy."""
+        epot = a.get_potential_energy() / len(a)
+        ekin = a.get_kinetic_energy() / len(a)
+        print('Energy per atom: Epot = %.3feV  Ekin = %.3feV (T=%3.0fK)  '
+              'Etot = %.3feV' % (epot, ekin, ekin / (1.5 * units.kB),
+                                 epot + ekin))
+
+    # Now run the dynamics
+    dyn.attach(printenergy, interval=10)
+    printenergy()
+    dyn.run(steps)

--- a/salsa_dancing_molecules/simulations/nve.py
+++ b/salsa_dancing_molecules/simulations/nve.py
@@ -7,7 +7,7 @@ from asap3 import Trajectory, AsapError
 from ..materialsproject import MatClient
 
 
-def run_for_materials(formula, api_key, steps, output_path):
+def run_for_materials(formula, api_key, steps, output_path, repeat=0):
     """Run an MD simulation for Materials Project materials.
 
     Arguments:
@@ -17,6 +17,8 @@ def run_for_materials(formula, api_key, steps, output_path):
         steps: int       - the number of 1 fs steps to run the simulation for
         output_path: str - path to which to save the generated trajectory
                            data. They get saved to $output_path-$formula.traj.
+        repeat: int      - number of times to repeat the cell in each
+                           dimension. (Default: 0, no repetition)
     """
     with MatClient(api_key) as client:
         atoms_list = client.get_atoms(formula)
@@ -26,6 +28,9 @@ def run_for_materials(formula, api_key, steps, output_path):
 
         symbols = atoms.symbols
         output_name = f'{output_path}-{symbols}.traj'
+
+        if repeat > 0:
+            atoms = atoms.repeat(repeat)
 
         try:
             print(f'Simulating for {symbols}')


### PR DESCRIPTION
This adds a command for running an NVE simulation with materials from Materials Project. One supplies a chemical formula and an API key and materials are fetched and MD performed on them.

Some remaining things to change are allowing to specify atomic potential parameters as well as initial temperature, but we have a separate task for the potential and I think the temperature can be added as a separate task as well.