### PR TITLE
materialsproject: prevent materials from overwriting each other

### DIFF
--- a/salsa_dancing_molecules/materialsproject.py
+++ b/salsa_dancing_molecules/materialsproject.py
@@ -46,6 +46,42 @@ class MatClient(MPRester):
         ]
         return atoms
 
+    def _pickle(self, atom, output_dir, id=-1):
+        """Pickle an atom.
+
+        Pickle an atom and save it to a file on disk named the
+        material's chemical formula and an optional index number.
+
+        arguments:
+            atom: ASE atom - atom object to pickle
+            output_dir: str - directory in which to save the pickles
+            id: int - the numerical ID to append to the file name. -1
+                      means no ID is wanted
+
+        returns:
+            (success: bool, name: str)
+                success is True if the material was successfully
+                downloaded and name is the name of the resulting
+                pickle file in output_dir
+        """
+        try:
+            if id == -1:
+                name = f"{atom.get_chemical_formula()}.pickle"
+            else:
+                name = f"{atom.get_chemical_formula()}-{id}.pickle"
+            path = f"{output_dir}/{name}"
+
+            with open(path, 'xb') as file:
+                pickle.dump(atom, file)
+            return (True, name)
+        except FileExistsError:
+            # If the atom without an ID collided, automatically create
+            # one with an ID.
+            if id == -1:
+                return self._pickle(atom, output_dir, 0)
+            else:
+                return (False, "")
+
     def pickle_atoms(self, formula, output_dir):
         """Download and pickle a material.
 
@@ -53,15 +89,30 @@ class MatClient(MPRester):
         formula and save a pickled ASE atoms in output_dir.
 
         Atoms are saved to files named their chemical formula with
-        the file extension .pickle.
+        the file extension .pickle. Materials with the same chemical
+        formula will have an index number appended at the end of the
+        material.
 
         arguments:
             formula:    str - chemical formula to search for, ex. 'Li-Fe-O'
             output_dir: str - path to a directory in which to save the
                               atom objects
+
+        returns:
+            saved_atoms: str - list of names of the pickle files
+                               saved in output_dir
         """
         atoms = self.get_atoms(formula)
+        saved_atoms = []
         for atom in atoms:
-            path = f"{output_dir}/{atom.get_chemical_formula()}.pickle"
-            with open(path, 'wb') as file:
-                pickle.dump(atom, file)
+            # To avoid overwriting an atom object with identical
+            # chemical formula, append an id that is incremented until
+            # one that is free is found.
+            id = -1
+            success = False
+            while not success:
+                success, name = self._pickle(atom, output_dir, id)
+                id += 1
+            saved_atoms.append(name)
+
+        return saved_atoms

--- a/salsa_dancing_molecules/unit_test/test_materialsproject.py
+++ b/salsa_dancing_molecules/unit_test/test_materialsproject.py
@@ -1,0 +1,68 @@
+"""Unit tests for the materialsproject module."""
+import pytest
+import uuid
+
+from os import remove
+from os.path import exists
+
+from ..materialsproject import MatClient
+
+
+# This custom mock class is needed because the unittest mock class can
+# not be pickled.
+class Atom:
+    """Mock atom class."""
+
+    def __init__(self, formula):
+        """Init the mock atom with a chemical formula."""
+        self.formula = formula
+
+    def get_chemical_formula(self):
+        """Return a mocked chemical formula."""
+        return self.formula
+
+
+class TestPickle:
+    """Test the pickle functionality of MatClient."""
+
+    def setup_class(self):
+        """Initialise the tests."""
+        self.client = MatClient('afakeapikey')
+        self.atom = Atom(uuid.uuid4())
+
+    def test_collision_without_id(self):
+        """Test colliding when no ID is requested."""
+        # Pickle the same atom twice and check if we get two files.
+        success0, name0 = self.client._pickle(self.atom, '.')
+        assert success0
+        assert name0 == f'{self.atom.get_chemical_formula()}.pickle'
+        assert exists(name0)
+
+        success1, name1 = self.client._pickle(self.atom, '.')
+        assert success1
+        assert name1 == f'{self.atom.get_chemical_formula()}-0.pickle'
+        assert exists(name1)
+
+        remove(name0)
+        remove(name1)
+
+    def test_collision_with_id(self):
+        """Test colliding when an ID is requested."""
+        # Create pickle with ID 0
+        success0, name0 = self.client._pickle(self.atom, '.', 0)
+        assert success0
+        assert name0 == f'{self.atom.get_chemical_formula()}-0.pickle'
+        assert exists(name0)
+
+        # Creating a pickle with the same name should fail.
+        success1, _ = self.client._pickle(self.atom, '.', 0)
+        assert not success1
+
+        # Creating a pickle with a new ID should succeed.
+        success2, name2 = self.client._pickle(self.atom, '.', 1)
+        assert success2
+        assert name2 == f'{self.atom.get_chemical_formula()}-1.pickle'
+        assert exists(name2)
+
+        remove(name0)
+        remove(name2)


### PR DESCRIPTION
When pickling materials, prevent materials with the same chemical formula from overwriting each other.