### PR TITLE
startup_script: add error message if no Materialsproject material is found

### DIFF
--- a/salsa_dancing_molecules/startup/startup_script.py
+++ b/salsa_dancing_molecules/startup/startup_script.py
@@ -65,6 +65,9 @@ def start(args):
                                                         work_path +
                                                         '/materials',
                                                         mp_materials)
+            if len(downloaded_materials) == 0:
+                print('Error: No Materialsproject materials found!')
+                sys.exit(1)
 
             # Replace all mp_ prefixed materials with the actual
             # downloaded materials.


### PR DESCRIPTION
Before adding a proper error message if no Materialsproject material was found, one would get a rather incromprehensible message about workspace_path not being defined.