### PR TITLE
post_process: only return the final MSD average

### DIFF
--- a/salsa_dancing_molecules/post_process/post_simulation_calculation.py
+++ b/salsa_dancing_molecules/post_process/post_simulation_calculation.py
@@ -98,7 +98,7 @@ def post_simulation_calculation(sim_info):
     cohesive_energy = calculate_cohesive_energy(configs, t0)
 
     result_dict = {}
-    result_dict["MSD_avr"] = MSD_avr
+    result_dict["MSD_avr"] = MSD_avr[-1]
     result_dict["self_diffusion_coefficient"] = self_diffusion_coefficient
     result_dict["heat_capacity"] = heat_capacity
     result_dict["debye_temperature"] = debye_temperature

--- a/salsa_dancing_molecules/unit_test/test_materialsproject.py
+++ b/salsa_dancing_molecules/unit_test/test_materialsproject.py
@@ -27,7 +27,7 @@ class TestPickle:
 
     def setup_class(self):
         """Initialise the tests."""
-        self.client = MatClient('afakeapikey')
+        self.client = MatClient('a' * 32)
         self.atom = Atom(uuid.uuid4())
 
     def test_collision_without_id(self):


### PR DESCRIPTION
For the final result of the calculations, we are only interested in the final average mean square displacement.