### PR TITLE
nve, simulation_starter: fix missing AsapError import

### DIFF
--- a/example_simulation/simulation_config_materialsproject.conf
+++ b/example_simulation/simulation_config_materialsproject.conf
@@ -5,11 +5,13 @@
 # formulas to be queried from Materialsproject. mp_Fe-S will cause all
 # materials with iron and sulfur to be downloaded and a worker json
 # configuration will be generated for each material.
-material = [gold_fcc,mp_C-O,mp_Fe-S]
+material = [gold_fcc,mp_Ar,mp_Ne]
 materials_path = /path/to/example_simulation/materials
 workspace_path = /path/to/example_workspace_materialsproject
 ensemble = [NVE]
-potential = [Lennard_Jones,EMT]
+potential = [lennard-jones]
 steps = 100
+initial-temperature = 40
+repeat = 2
 cell_size = 5
-use_asap = false
+use-asap = False

--- a/salsa_dancing_molecules/simulations/nve.py
+++ b/salsa_dancing_molecules/simulations/nve.py
@@ -8,7 +8,7 @@ from ..materialsproject import MatClient
 from ..lennardjonesparse import parse_lj_params
 
 try:
-    from asap3 import Trajectory
+    from asap3 import Trajectory, AsapError
 except ImportError:
     print("asap3 import failed. This should only happen when building docs.")
 

--- a/salsa_dancing_molecules/worker_process/simulation_starter.py
+++ b/salsa_dancing_molecules/worker_process/simulation_starter.py
@@ -2,7 +2,7 @@
 from ..simulations.simulation import run
 
 try:
-    from asap3 import Trajectory
+    from asap3 import Trajectory, AsapError
 except ImportError:
     print("asap3 import failed. This should only happen when building docs.")
 


### PR DESCRIPTION
During documentation generation, the AsapError import was removed by mistake.